### PR TITLE
Prevent the scrollview flying in the very first loading 

### DIFF
--- a/STPullToRefresh/STPullToRefreshHelper.m
+++ b/STPullToRefresh/STPullToRefreshHelper.m
@@ -91,7 +91,13 @@
 }
 
 - (void)setStateLoadingAnimated:(BOOL)animated {
-    [self setState:STPullToRefreshStateLoading animated:animated];
+    __weak __typeof__(self) wself = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __typeof__(self) sself = wself;
+        if (sself) {
+            [sself setState:STPullToRefreshStateLoading animated:animated];
+        }
+    });
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {


### PR DESCRIPTION
This is a temporary solution to prevent scrollview misbehaviour when the state should be "Loading" while the scrollview real size is not applied yet. This occurs on iPad and for iOS7 is very serious!
